### PR TITLE
Dev

### DIFF
--- a/Dixie/Dixie.fsproj
+++ b/Dixie/Dixie.fsproj
@@ -1,13 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
-    <Compile Include="Util\Types.fs" />
-    <Compile Include="Util\Attributes.fs" />
-    <Compile Include="Util\Generic.fs" />
+    <Compile Include="Util/Types.fs" />
+    <Compile Include="Util/Attributes.fs" />
+    <Compile Include="Util/Generic.fs" />
+    <Compile Include="Util/Table.fs" />
   </ItemGroup>
-
 </Project>

--- a/Dixie/Util/Attributes.fs
+++ b/Dixie/Util/Attributes.fs
@@ -39,7 +39,7 @@ let tryFindAttribute<'T when 'T :> System.Attribute> (prop: Reflection.PropertyI
 // val isRef: System.Reflection.PropertyInfo -> System.Reflection.PropertyInfo -> bool
 // propT: the property with the OneToMany attribute
 // propA: the property which is a reference to propT
-/// Check's whether propA is referencing propT via the Ref attribute's parent member
+/// Check's whether propA is referencing propT
 let isRef (propT: Reflection.PropertyInfo) propA =
     if hasAttribute<RefAttribute> propA then
         match (tryFindAttribute<RefAttribute> propA) with

--- a/Dixie/Util/Table.fs
+++ b/Dixie/Util/Table.fs
@@ -1,0 +1,13 @@
+module Dixie.Util.Table
+open Dixie.Util.Types
+
+// val format: Table -> string
+// table: the table to be formatted
+// Formats a table for pretty printing
+let format (table: Table) =
+    let schema =
+        table.schema
+        |> Map.toSeq
+        |> Seq.map (fun (cName, cType) -> sprintf "%s: %s" cName cType)
+        |> String.concat " | "
+    sprintf "%s:\n%s" table.name schema

--- a/Playground/Program.fs
+++ b/Playground/Program.fs
@@ -1,7 +1,7 @@
 ﻿open System
 open Dixie.Util.Attributes
 open Dixie.Util.Generic
-open Dixie.Util.Types
+open Dixie.Util
 
 // Users
 // | id | name | email
@@ -25,23 +25,12 @@ and Post =
 // Liked
 // | id | ref user | ref post
 
-// val formatTable: Table -> string
-// Formats a table for pretty printing
-// table: the table to be formatted
-let formatTable (table: Table) =
-    let schema =
-        table.schema
-        |> Map.toSeq
-        |> Seq.map (fun (cName, cType) -> sprintf "%s: %s" cName cType)
-        |> String.concat " | "
-    sprintf "%s:\n%s" table.name schema
-
 [<EntryPoint>]
 // val main: string [] -> int
 // prints out a formatted table for the User record type defined above
 let main _ =
     mapType typeof<User>
-    |> List.map formatTable
+    |> List.map (Table.format)
     |> List.iter (printfn "%s")
 
     Console.ReadLine()


### PR DESCRIPTION
This merge handles the addition of `Dixie.Util.Table` as a result of moving `formatTable` from the playground to the library itself, along with a quick fix to a comment in `Dixie.Util.Attributes`